### PR TITLE
Add monthly budget tracking with progress bar and expense filtering

### DIFF
--- a/.cursor/rules/project-overview.mdc
+++ b/.cursor/rules/project-overview.mdc
@@ -1,0 +1,73 @@
+---
+description: Expense Tracker iOS project layout, architecture, and build commands
+alwaysApply: true
+---
+
+# Expense Tracker — Project Overview
+
+iOS app (SwiftUI) for tracking daily expenses and viewing analytics. Firebase Realtime Database for persistence; Gmail sign-in via Firebase Auth.
+
+## Repository layout
+
+```
+Expense-Tracker/
+├── ExpenseTracker/
+│   ├── ExpenseTracker.xcodeproj
+│   ├── ExpenseTracker/          # App source
+│   │   ├── Data/Models/
+│   │   ├── Domain/UseCase/
+│   │   ├── Presentation/
+│   │   ├── Navigation/
+│   │   ├── Helper/
+│   │   └── Extension/
+│   └── ExpenseTrackerUnitTests/
+└── README.md
+```
+
+## Architecture
+
+Layered MVVM with coordinator-based navigation:
+
+| Layer | Location | Responsibility |
+|-------|----------|----------------|
+| Data | `Data/Models/` | Domain models (`User`, `ExpenseList`, `PlaceAddress`) |
+| Domain | `Domain/UseCase/` | Business logic (`FirebaseRealtimeDBUseCase`, `LoginGmailUseCase`) |
+| Presentation | `Presentation/` | `*Screen`, `*ViewModel`, `*UIModel` |
+| Navigation | `Navigation/` | `AppCoordinator`, `Screen` enum, FlowStacks routing |
+
+- Screens are SwiftUI `View` structs; ViewModels are `final class` conforming to `ObservableObject`.
+- Navigation uses FlowStacks (`Router`, `Screen` cases with embedded ViewModels).
+- Shared constants live in `Helper/Constants.swift` via nested `enum Constants` extensions.
+- Reusable UI helpers live in `Helper/UI/`; Swift extensions in `Extension/`.
+
+## Build & verify
+
+Run from the `ExpenseTracker/` directory (where `ExpenseTracker.xcodeproj` lives):
+
+```bash
+cd ExpenseTracker
+
+xcodebuild -project ExpenseTracker.xcodeproj \
+           -scheme "ExpenseTracker" \
+           -configuration Debug \
+           -sdk iphonesimulator \
+           -destination 'id=5B796620-1BAE-4D71-A5F0-3428712C9C3C' \
+           build
+```
+
+Run unit tests:
+
+```bash
+xcodebuild -project ExpenseTracker.xcodeproj \
+           -scheme "ExpenseTracker" \
+           -configuration Debug \
+           -sdk iphonesimulator \
+           -destination 'id=5B796620-1BAE-4D71-A5F0-3428712C9C3C' \
+           test
+```
+
+## Dependencies
+
+- SwiftUI, Combine
+- Firebase (Auth, Realtime Database)
+- FlowStacks (navigation)

--- a/.cursor/rules/swift-conventions.mdc
+++ b/.cursor/rules/swift-conventions.mdc
@@ -1,0 +1,66 @@
+---
+description: Swift and SwiftUI coding conventions for Expense Tracker
+globs: "**/*.swift"
+alwaysApply: false
+---
+
+# Swift Conventions
+
+## Naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Screen | `*Screen` | `AddExpenseScreen` |
+| ViewModel | `*ViewModel` | `AddExpenseViewModel` |
+| Use case | `*UseCase` | `FirebaseRealtimeDBUseCase` |
+| UI model | `*UIModel` | `AlertUIModel`, `BarChartUIModel` |
+
+## ViewModels
+
+- `final class` conforming to `ObservableObject`
+- Inject dependencies via `init`; default to shared singletons where the codebase already does (e.g. `FirebaseRealtimeDBUseCase.shared`)
+- Expose read-only state with `@Published private(set) var`
+- User-editable fields use `@Published var`
+- Use `[weak self]` in async/completion closures
+
+```swift
+final class AddExpenseViewModel: ObservableObject {
+    private let firebaseRealtimeDBUseCase: FirebaseRealtimeDBUseCase
+    @Published private(set) var state: State
+    @Published var selectedCurrency: String
+
+    init(firebaseRealtimeDBUseCase: FirebaseRealtimeDBUseCase = .shared) {
+        self.firebaseRealtimeDBUseCase = firebaseRealtimeDBUseCase
+    }
+}
+```
+
+## Screens
+
+- SwiftUI `struct` conforming to `View`
+- Accept ViewModel via `init` or `@ObservedObject`
+- Use `@EnvironmentObject` for `AppCoordinatorViewModel` navigation
+- Extract subviews as `private var` computed properties when the body grows
+- Reference colors and strings from `Constants.AppColors` / `Constants.AppText`
+
+## Use cases
+
+- `final class` in `Domain/UseCase/`
+- Singleton pattern via `static let shared` where appropriate
+- Firebase access stays in use cases, not in ViewModels or Screens
+
+## Navigation
+
+- Add new destinations to the `Screen` enum in `Navigation/Screen.swift`
+- Wire routes in `AppCoordinator` and navigation methods in `AppCoordinatorViewModel`
+
+## Constants & extensions
+
+- App-wide values: nested enums under `enum Constants` in `Helper/Constants.swift`
+- Type extensions: `Extension/` (e.g. `Color+Extension`, `Date+Extension`)
+
+## General
+
+- Match existing file header style and folder placement
+- Keep changes scoped; follow existing patterns before introducing new abstractions
+- Do not commit `GoogleService-Info.plist` secrets or modify `.gitignore` without reason

--- a/ExpenseTracker/ExpenseTracker.xcodeproj/project.pbxproj
+++ b/ExpenseTracker/ExpenseTracker.xcodeproj/project.pbxproj
@@ -69,6 +69,12 @@
 		04CBF14A2B15230700DF5B06 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CBF1492B15230700DF5B06 /* Color+Extension.swift */; };
 		04D448522C084E2B00FB3640 /* ExpenseTrackerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D448512C084E2B00FB3640 /* ExpenseTrackerUnitTests.swift */; };
 		04D4485A2C084E8400FB3640 /* ConstantsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D448592C084E8400FB3640 /* ConstantsTests.swift */; };
+		04MBGT012D10000100BUDGET /* MonthlyBudget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04MBGT002D10000100BUDGET /* MonthlyBudget.swift */; };
+		04MBGT032D10000100BUDGET /* MonthlyBudgetUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04MBGT022D10000100BUDGET /* MonthlyBudgetUseCase.swift */; };
+		04BGPR012D20000100BUDGET /* BudgetProgressUIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BGPR002D20000100BUDGET /* BudgetProgressUIModel.swift */; };
+		04BGPR032D20000100BUDGET /* BudgetProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BGPR022D20000100BUDGET /* BudgetProgressView.swift */; };
+		04BGEX012D30000100BUDGET /* BudgetExpenseItemUIModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BGEX002D30000100BUDGET /* BudgetExpenseItemUIModel.swift */; };
+		04BGEX032D30000100BUDGET /* BudgetExpenseSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04BGEX022D30000100BUDGET /* BudgetExpenseSheetView.swift */; };
 		04D448632C097D7F00FB3640 /* AnalysisGraphType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D448622C097D7F00FB3640 /* AnalysisGraphType.swift */; };
 		04EEC1A82B0E30F300AC445E /* LocationSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EEC1A72B0E30F300AC445E /* LocationSearchView.swift */; };
 		04EEC1AB2B0E336300AC445E /* LocationSearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04EEC1AA2B0E336300AC445E /* LocationSearchViewModel.swift */; };
@@ -145,6 +151,12 @@
 		04CBF1472B15216800DF5B06 /* TextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextButtonStyle.swift; sourceTree = "<group>"; };
 		04CBF1492B15230700DF5B06 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		04D4484F2C084E2B00FB3640 /* ExpenseTrackerUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExpenseTrackerUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		04MBGT002D10000100BUDGET /* MonthlyBudget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyBudget.swift; sourceTree = "<group>"; };
+		04MBGT022D10000100BUDGET /* MonthlyBudgetUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyBudgetUseCase.swift; sourceTree = "<group>"; };
+		04BGPR002D20000100BUDGET /* BudgetProgressUIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetProgressUIModel.swift; sourceTree = "<group>"; };
+		04BGPR022D20000100BUDGET /* BudgetProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetProgressView.swift; sourceTree = "<group>"; };
+		04BGEX002D30000100BUDGET /* BudgetExpenseItemUIModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetExpenseItemUIModel.swift; sourceTree = "<group>"; };
+		04BGEX022D30000100BUDGET /* BudgetExpenseSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetExpenseSheetView.swift; sourceTree = "<group>"; };
 		04D448512C084E2B00FB3640 /* ExpenseTrackerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpenseTrackerUnitTests.swift; sourceTree = "<group>"; };
 		04D448592C084E8400FB3640 /* ConstantsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTests.swift; sourceTree = "<group>"; };
 		04D448622C097D7F00FB3640 /* AnalysisGraphType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisGraphType.swift; sourceTree = "<group>"; };
@@ -192,6 +204,7 @@
 			children = (
 				041152932B179F1100D93FFC /* LoginGmailUseCase.swift */,
 				04C410E32B3C63270084BF81 /* FirebaseRealtimeDBUseCase.swift */,
+				04MBGT022D10000100BUDGET /* MonthlyBudgetUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -286,6 +299,8 @@
 				047A7ECB2B5E47B600B11B10 /* AlertUIModel.swift */,
 				04346F1A2C059A8D003CCFDC /* BarChartUIModel.swift */,
 				04C4449D2C0740C7000D47A6 /* BarChartItemUIModel.swift */,
+				04BGPR002D20000100BUDGET /* BudgetProgressUIModel.swift */,
+				04BGEX002D30000100BUDGET /* BudgetExpenseItemUIModel.swift */,
 			);
 			path = UIModel;
 			sourceTree = "<group>";
@@ -356,6 +371,7 @@
 				045294802B30ADF800BB2513 /* User.swift */,
 				04C410E52B3C87B30084BF81 /* ExpenseList.swift */,
 				04B1BFED2B4EB6DE00ABA765 /* PlaceAddress.swift */,
+				04MBGT002D10000100BUDGET /* MonthlyBudget.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -450,6 +466,8 @@
 				04CBF1472B15216800DF5B06 /* TextButtonStyle.swift */,
 				047A7EC72B5E3C1E00B11B10 /* AlertView.swift */,
 				047A7EC92B5E3D2900B11B10 /* AlertViewModifier.swift */,
+				04BGPR022D20000100BUDGET /* BudgetProgressView.swift */,
+				04BGEX022D30000100BUDGET /* BudgetExpenseSheetView.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -659,6 +677,12 @@
 				04073E512B17092800BDE21B /* AppDelegate.swift in Sources */,
 				04CBF14A2B15230700DF5B06 /* Color+Extension.swift in Sources */,
 				04C410E42B3C63270084BF81 /* FirebaseRealtimeDBUseCase.swift in Sources */,
+				04MBGT012D10000100BUDGET /* MonthlyBudget.swift in Sources */,
+				04MBGT032D10000100BUDGET /* MonthlyBudgetUseCase.swift in Sources */,
+				04BGPR012D20000100BUDGET /* BudgetProgressUIModel.swift in Sources */,
+				04BGPR032D20000100BUDGET /* BudgetProgressView.swift in Sources */,
+				04BGEX012D30000100BUDGET /* BudgetExpenseItemUIModel.swift in Sources */,
+				04BGEX032D30000100BUDGET /* BudgetExpenseSheetView.swift in Sources */,
 				041D19CE2B55072000FB8978 /* CurrencyPickerView.swift in Sources */,
 				047A7ECC2B5E47B600B11B10 /* AlertUIModel.swift in Sources */,
 			);
@@ -816,7 +840,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -848,7 +872,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ExpenseTracker/ExpenseTracker/Data/Models/MonthlyBudget.swift
+++ b/ExpenseTracker/ExpenseTracker/Data/Models/MonthlyBudget.swift
@@ -1,0 +1,33 @@
+//
+//  MonthlyBudget.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 6/7/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class MonthlyBudget {
+
+    var amount: Double
+    var currency: String
+    var month: Int
+    var year: Int
+    var budgetDate: Date
+
+    init(
+        amount: Double,
+        currency: String,
+        month: Int,
+        year: Int,
+        budgetDate: Date
+    ) {
+        self.amount = amount
+        self.currency = currency
+        self.month = month
+        self.year = year
+        self.budgetDate = budgetDate
+    }
+}

--- a/ExpenseTracker/ExpenseTracker/Domain/UseCase/FirebaseRealtimeDBUseCase.swift
+++ b/ExpenseTracker/ExpenseTracker/Domain/UseCase/FirebaseRealtimeDBUseCase.swift
@@ -137,6 +137,34 @@ final class FirebaseRealtimeDBUseCase {
         }
     }
 
+    /// Fetches the most recent expense lists without using pagination cursor state.
+    func getRecentExpenseLists(
+        queryLimit: UInt,
+        completion: @escaping ([ExpenseList]?) -> Void
+    ) {
+        guard let databasePath = databaseReference else {
+            NSLog("Database path not found")
+            completion(nil)
+            return
+        }
+
+        databasePath
+            .queryOrdered(byChild: "id")
+            .queryLimited(toLast: queryLimit)
+            .observeSingleEvent(of: .value) { [weak self] snapshot in
+                guard let self = self else { return }
+                var dataModels: [ExpenseList] = []
+                for child in snapshot.children {
+                    if let snapshot = child as? DataSnapshot {
+                        if let dataModel = self.getExpenseModel(snapshot: snapshot) {
+                            dataModels.append(dataModel)
+                        }
+                    }
+                }
+                completion(dataModels)
+            }
+    }
+
     // MARK: - Model conversion
 
     private func getExpenseModel(snapshot: DataSnapshot) ->  ExpenseList? {

--- a/ExpenseTracker/ExpenseTracker/Domain/UseCase/MonthlyBudgetUseCase.swift
+++ b/ExpenseTracker/ExpenseTracker/Domain/UseCase/MonthlyBudgetUseCase.swift
@@ -1,0 +1,65 @@
+//
+//  MonthlyBudgetUseCase.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 6/7/26.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+final class MonthlyBudgetUseCase {
+
+    static let shared = MonthlyBudgetUseCase()
+
+    let modelContainer: ModelContainer
+
+    private var modelContext: ModelContext {
+        modelContainer.mainContext
+    }
+
+    private init() {
+        modelContainer = try! ModelContainer(for: MonthlyBudget.self)
+    }
+
+    func hasBudgetForCurrentMonth() -> Bool {
+        let components = Calendar.current.dateComponents([.month, .year], from: .now)
+        guard let month = components.month, let year = components.year else {
+            return false
+        }
+        return fetchBudget(month: month, year: year) != nil
+    }
+
+    func fetchBudget(month: Int, year: Int) -> MonthlyBudget? {
+        let predicate = #Predicate<MonthlyBudget> { budget in
+            budget.month == month && budget.year == year
+        }
+        let descriptor = FetchDescriptor<MonthlyBudget>(predicate: predicate)
+        return try? modelContext.fetch(descriptor).first
+    }
+
+    func saveBudget(amount: Double, currency: String, date: Date) throws {
+        let components = Calendar.current.dateComponents([.month, .year], from: date)
+        guard let month = components.month, let year = components.year else {
+            throw CommonError.invalidData
+        }
+
+        if let existingBudget = fetchBudget(month: month, year: year) {
+            existingBudget.amount = amount
+            existingBudget.currency = currency
+            existingBudget.budgetDate = date
+        } else {
+            let budget = MonthlyBudget(
+                amount: amount,
+                currency: currency,
+                month: month,
+                year: year,
+                budgetDate: date
+            )
+            modelContext.insert(budget)
+        }
+
+        try modelContext.save()
+    }
+}

--- a/ExpenseTracker/ExpenseTracker/ExpenseTrackerApp.swift
+++ b/ExpenseTracker/ExpenseTracker/ExpenseTrackerApp.swift
@@ -5,11 +5,12 @@
 //  Created by nimble on 13/11/23.
 //
 
+import SwiftData
 import SwiftUI
 
 @main
 struct ExpenseTrackerApp: App {
-    
+
     // register app delegate for Firebase setup
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
@@ -21,5 +22,6 @@ struct ExpenseTrackerApp: App {
                 AppCoordinator(coordinator: AppCoordinatorViewModel())
             }
         }
+        .modelContainer(MonthlyBudgetUseCase.shared.modelContainer)
     }
 }

--- a/ExpenseTracker/ExpenseTracker/Extension/Date+Extension.swift
+++ b/ExpenseTracker/ExpenseTracker/Extension/Date+Extension.swift
@@ -20,4 +20,12 @@ extension Date {
         let components = calendar.dateComponents([.day], from: start, to: end)
         return components.day
     }
+
+    var yearMonthKey: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        return formatter.string(from: self)
+    }
 }

--- a/ExpenseTracker/ExpenseTracker/Extension/DateFormatter+Extenson.swift
+++ b/ExpenseTracker/ExpenseTracker/Extension/DateFormatter+Extenson.swift
@@ -34,4 +34,13 @@ extension DateFormatter {
         displayDateFormatter.calendar = Calendar(identifier: .gregorian)
         return displayDateFormatter
     }()
+
+    /// Result: "06/07/2026"
+    static let budgetDateFormat: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "dd/MM/yyyy"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.calendar = Calendar(identifier: .gregorian)
+        return dateFormatter
+    }()
 }

--- a/ExpenseTracker/ExpenseTracker/Extension/String+Extension.swift
+++ b/ExpenseTracker/ExpenseTracker/Extension/String+Extension.swift
@@ -17,4 +17,10 @@ extension String {
         }
         return "$"
     }
+
+    var yearMonthKey: String {
+        let parts = split(separator: "-")
+        guard parts.count >= 2 else { return self }
+        return "\(parts[0])-\(parts[1])"
+    }
 }

--- a/ExpenseTracker/ExpenseTracker/Extension/View+Extension.swift
+++ b/ExpenseTracker/ExpenseTracker/Extension/View+Extension.swift
@@ -41,4 +41,13 @@ extension View {
             )
         )
     }
+
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
 }

--- a/ExpenseTracker/ExpenseTracker/Helper/CommonError.swift
+++ b/ExpenseTracker/ExpenseTracker/Helper/CommonError.swift
@@ -13,6 +13,7 @@ enum CommonError: LocalizedError {
     case noPreviousAccountFound
     case signOutFailed
     case firebaseSignInFailed
+    case invalidData
     case unknown
 
     var localizedDescription: String {
@@ -25,6 +26,8 @@ enum CommonError: LocalizedError {
             return "Sign out process failed, try again"
         case .firebaseSignInFailed:
             return "Sign in to firebase failed"
+        case .invalidData:
+            return "Invalid data provided"
         case .unknown:
             return "Unknown error occurred"
         }

--- a/ExpenseTracker/ExpenseTracker/Helper/Constants.swift
+++ b/ExpenseTracker/ExpenseTracker/Helper/Constants.swift
@@ -16,6 +16,8 @@ extension Constants {
         static let blueButtonColor = "#2529AD"
         static let tabSelectionColor = "#3BC1AF"
         static let errorBackgroundColor = "#E72E1B"
+        static let budgetSpentColor = "#E67E22"
+        static let budgetRemainingColor = "#3BC1AF"
     }
 }
 
@@ -33,6 +35,24 @@ extension Constants {
         static let tabAnalysis = "Analysis"
         static let addExpense = "Add expense"
         static let selectDate = "Select date"
+        static let monthlyBudget = "Monthly budget"
+        static let budgetAmount = "Budget amount"
+        static let selectCurrency = "Select currency"
+        static let saveBudget = "Save budget"
+        static let updateBudget = "Update budget"
+        static let budgetAlertTitle = "Set monthly budget"
+        static let budgetAlertMessage = "You have not set a budget for this month. Set one to track your spending."
+        static let setBudget = "Set budget"
+        static let cancel = "Cancel"
+        static let budgetSaveSuccess = "Monthly budget saved successfully."
+        static let budgetSaveFailed = "Failed to save monthly budget."
+        static let budgetInvalidAmount = "Please enter a valid budget amount."
+        static let remainingThisMonth = "Remaining this month"
+        static let budgetUsedFormat = "%@ of %@ %@ used"
+        static let done = "Done"
+        static let filterExpenses = "Filter expenses"
+        static let budgetExpenseDetails = "Monthly expenses"
+        static let budgetExpenseEmpty = "No expenses found for this month."
     }
 }
 

--- a/ExpenseTracker/ExpenseTracker/Helper/UI/BudgetExpenseSheetView.swift
+++ b/ExpenseTracker/ExpenseTracker/Helper/UI/BudgetExpenseSheetView.swift
@@ -1,0 +1,77 @@
+//
+//  BudgetExpenseSheetView.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 8/7/26.
+//
+
+import SwiftUI
+
+struct BudgetExpenseSheetView: View {
+
+    @ObservedObject private var viewModel: ProfileScreenViewModel
+
+    private var currency: String {
+        viewModel.budgetProgressUIModel?.currency ?? ""
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.budgetExpenseItems.isEmpty {
+                    Text(Constants.AppText.budgetExpenseEmpty)
+                        .font(.system(size: 14.0))
+                        .foregroundColor(.gray)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    List {
+                        ForEach(viewModel.budgetExpenseItems) { item in
+                            budgetExpenseRow(item: item)
+                        }
+                    }
+                    .listStyle(.plain)
+                }
+            }
+            .navigationTitle(Constants.AppText.budgetExpenseDetails)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(Constants.AppText.done) {
+                        viewModel.onDismissBudgetExpenseSheet()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func budgetExpenseRow(item: BudgetExpenseItemUIModel) -> some View {
+        Button {
+            viewModel.onToggleBudgetExpenseItem(id: item.id)
+        } label: {
+            HStack(spacing: 12.0) {
+                Image(
+                    systemName: item.isSelected ?
+                    "checkmark.square.fill" :
+                    "square"
+                )
+                .foregroundColor(
+                    Color(hexString: Constants.AppColors.tabSelectionColor)
+                )
+                Text(item.name)
+                    .font(.system(size: 16.0))
+                    .foregroundColor(.primary)
+                Spacer()
+                Text("\(item.cost.fractionTwoDigitString) \(currency)")
+                    .font(.system(size: 14.0, weight: .semibold))
+                    .foregroundColor(.primary)
+            }
+            .padding(.vertical, 4.0)
+        }
+        .buttonStyle(.plain)
+    }
+
+    init(viewModel: ProfileScreenViewModel) {
+        self.viewModel = viewModel
+    }
+}

--- a/ExpenseTracker/ExpenseTracker/Helper/UI/BudgetProgressView.swift
+++ b/ExpenseTracker/ExpenseTracker/Helper/UI/BudgetProgressView.swift
@@ -1,0 +1,96 @@
+//
+//  BudgetProgressView.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 7/7/26.
+//
+
+import SwiftUI
+
+struct BudgetProgressView: View {
+
+    @ObservedObject private var viewModel: ProfileScreenViewModel
+    private let onTapFilterExpenses: () -> Void
+    private let onTapUpdateBudget: () -> Void
+
+    var body: some View {
+        if let uiModel = viewModel.budgetProgressUIModel {
+            VStack(alignment: .leading, spacing: 8.0) {
+                Text("\(Constants.AppText.remainingThisMonth): \(remainingText(uiModel: uiModel))")
+                    .font(.system(size: 16.0, weight: .semibold))
+
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 6.0)
+                            .fill(Color(hexString: Constants.AppColors.budgetRemainingColor))
+
+                        RoundedRectangle(cornerRadius: 6.0)
+                            .fill(Color(hexString: Constants.AppColors.budgetSpentColor))
+                            .frame(width: geometry.size.width * uiModel.spentFraction)
+                    }
+                }
+                .frame(height: 12.0)
+
+                Text(usageText(uiModel: uiModel))
+                    .font(.system(size: 12.0))
+                    .foregroundColor(.gray)
+
+                VStack(spacing: 8.0) {
+                    actionButton(
+                        title: Constants.AppText.filterExpenses,
+                        action: onTapFilterExpenses
+                    )
+
+                    if !viewModel.isUpdateBudgetVisible {
+                        actionButton(
+                            title: Constants.AppText.updateBudget,
+                            action: onTapUpdateBudget
+                        )
+                    }
+                }
+                .padding(.top, 4.0)
+            }
+            .padding(12.0)
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(12.0)
+        }
+    }
+
+    private func actionButton(title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 14.0, weight: .semibold))
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(
+            TextButtonStyle(
+                backgroundColor: Color(hexString: Constants.AppColors.blueButtonColor),
+                textColor: .white,
+                textPadding: EdgeInsets(top: 8.0, leading: 8.0, bottom: 8.0, trailing: 8.0)
+            )
+        )
+    }
+
+    private func remainingText(uiModel: BudgetProgressUIModel) -> String {
+        "\(uiModel.remainingAmount.fractionTwoDigitString) \(uiModel.currency)"
+    }
+
+    private func usageText(uiModel: BudgetProgressUIModel) -> String {
+        String(
+            format: Constants.AppText.budgetUsedFormat,
+            uiModel.spentAmount.fractionTwoDigitString,
+            uiModel.budgetAmount.fractionTwoDigitString,
+            uiModel.currency
+        )
+    }
+
+    init(
+        viewModel: ProfileScreenViewModel,
+        onTapFilterExpenses: @escaping () -> Void,
+        onTapUpdateBudget: @escaping () -> Void
+    ) {
+        self.viewModel = viewModel
+        self.onTapFilterExpenses = onTapFilterExpenses
+        self.onTapUpdateBudget = onTapUpdateBudget
+    }
+}

--- a/ExpenseTracker/ExpenseTracker/Presentation/Tabs/Profile/ProfileScreen.swift
+++ b/ExpenseTracker/ExpenseTracker/Presentation/Tabs/Profile/ProfileScreen.swift
@@ -8,11 +8,82 @@
 import SwiftUI
 
 struct ProfileScreen: View {
-    
+
     @EnvironmentObject var navigator: AppCoordinatorViewModel
     @ObservedObject private var viewModel: ProfileScreenViewModel
 
     private let onSignOutSuccess: () -> Void
+
+    private var budgetSectionView: some View {
+        VStack(alignment: .leading, spacing: 12.0) {
+            Text(Constants.AppText.monthlyBudget)
+                .font(.title3)
+
+            HStack {
+                Text(Constants.AppText.budgetAmount)
+                Spacer()
+                TextField("0.00", text: $viewModel.budgetAmount)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.trailing)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 140.0)
+            }
+
+            HStack {
+                Text(Constants.AppText.selectCurrency)
+                Spacer()
+                CurrencyPickerView(
+                    currencyList: Constants.AppData.currencyList,
+                    selectedCurrency: $viewModel.selectedCurrency
+                )
+            }
+
+            DatePicker(
+                selection: $viewModel.selectedDate,
+                displayedComponents: .date
+            ) {
+                Text(Constants.AppText.selectDate)
+            }
+            .onChange(of: viewModel.selectedDate) { _ in
+                viewModel.onSelectedDateChanged()
+            }
+
+            Text(
+                DateFormatter.budgetDateFormat.string(
+                    from: viewModel.selectedDate
+                )
+            )
+            .font(.system(size: 12.0))
+            .foregroundColor(.gray)
+
+            saveBudgetButton
+        }
+        .padding(12.0)
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(12.0)
+    }
+
+    private var saveBudgetButtonTitle: String {
+        viewModel.budgetProgressUIModel != nil ?
+        Constants.AppText.updateBudget :
+        Constants.AppText.saveBudget
+    }
+
+    private var saveBudgetButton: some View {
+        Button {
+            hideKeyboard()
+            viewModel.onTapSaveBudget()
+        } label: {
+            Text(saveBudgetButtonTitle)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(
+            TextButtonStyle(
+                backgroundColor: Color(hexString: Constants.AppColors.blueButtonColor),
+                textColor: .white
+            )
+        )
+    }
 
     private var signOutButton: some View {
         Button {
@@ -60,19 +131,80 @@ struct ProfileScreen: View {
     }
 
     var body: some View {
-        VStack {
-            Text(viewModel.user.name)
-                .font(.title2)
-            Text(viewModel.user.email)
-            searchLocationButton
-            seeCurrentLocationButton
-            signOutButton
+        NavigationStack {
+            ScrollView {
+                VStack {
+                    Text(viewModel.user.name)
+                        .font(.title2)
+                        .padding(.bottom, 2)
+                    Text(viewModel.user.email)
+                        .padding(.bottom, 8)
+
+                    if viewModel.budgetProgressUIModel != nil {
+                        BudgetProgressView(
+                            viewModel: viewModel,
+                            onTapFilterExpenses: {
+                                viewModel.onTapViewBudgetExpenses()
+                            },
+                            onTapUpdateBudget: {
+                                viewModel.onTapUpdateBudget()
+                            }
+                        )
+                        .padding(.bottom, 16)
+
+                        if viewModel.isUpdateBudgetVisible {
+                            budgetSectionView
+                                .padding(.bottom, 16)
+                        }
+                    } else {
+                        budgetSectionView
+                            .padding(.bottom, 16)
+                    }
+                    Spacer(minLength: 100)
+
+                    VStack(spacing: 4) {
+                        searchLocationButton
+                        seeCurrentLocationButton
+                        signOutButton
+                    }
+                }
+                .padding()
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .toolbar {
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button(Constants.AppText.done) {
+                        hideKeyboard()
+                    }
+                }
+            }
         }
-        .padding()
+        .onAppear {
+            viewModel.onAppear()
+        }
         .onChange(of: viewModel.authState) { state in
             if state == .signedOut {
                 onSignOutSuccess()
             }
+        }
+        .alertView(
+            isPresenting: $viewModel.isShowingAlert,
+            title: viewModel.alertData.title,
+            description: viewModel.alertData.description,
+            isError: viewModel.alertData.isError,
+            didTap: {
+                viewModel.isShowingAlert = false
+            }
+        )
+        .animation(.linear(duration: 0.2), value: viewModel.isShowingAlert)
+        .sheet(
+            isPresented: $viewModel.isBudgetExpenseSheetPresented,
+            onDismiss: {
+                viewModel.recalculateBudgetProgressFromSelectedItems()
+            }
+        ) {
+            BudgetExpenseSheetView(viewModel: viewModel)
         }
     }
 

--- a/ExpenseTracker/ExpenseTracker/Presentation/Tabs/Profile/ProfileScreenViewModel.swift
+++ b/ExpenseTracker/ExpenseTracker/Presentation/Tabs/Profile/ProfileScreenViewModel.swift
@@ -8,17 +8,64 @@
 import Combine
 import Foundation
 
+@MainActor
 final class ProfileScreenViewModel: ObservableObject {
 
     private let loginGmailUseCase: LoginGmailUseCaseProtocol
+    private let monthlyBudgetUseCase: MonthlyBudgetUseCase
+    private let firebaseRealtimeDBUseCase: FirebaseRealtimeDBUseCase
     let user: User
     private var cancellable = Set<AnyCancellable>()
     @Published var authState: AuthState = .signedIn
+    @Published var budgetAmount: String = ""
+    @Published var selectedCurrency: String
+    @Published var selectedDate = Date.now
+    @Published var isShowingAlert = false
+    @Published var isUpdateBudgetVisible = false
+    @Published var isBudgetExpenseSheetPresented = false
+    @Published private(set) var isSaveSuccess = false
+    @Published private(set) var hasCurrentMonthBudget = false
+    @Published private(set) var budgetProgressUIModel: BudgetProgressUIModel?
+    @Published private(set) var budgetExpenseItems: [BudgetExpenseItemUIModel] = []
 
+    private let monthlyExpenseQueryLimit: UInt = 60
+    private var budgetProgressRequestId = UUID()
+    private var currentMonthBudgetAmount: Double = 0
+    private var currentMonthBudgetCurrency: String = "THB"
 
-    init(user: User, loginGmailUseCase: LoginGmailUseCaseProtocol = LoginGmailUseCase()) {
+    var alertData: AlertUIModel {
+        if isSaveSuccess {
+            return .init(
+                title: "Success!",
+                description: Constants.AppText.budgetSaveSuccess,
+                isError: false
+            )
+        }
+        return .init(
+            title: "Error!",
+            description: budgetAmount.isEmpty ?
+            Constants.AppText.budgetInvalidAmount :
+            Constants.AppText.budgetSaveFailed,
+            isError: true
+        )
+    }
+
+    init(
+        user: User,
+        loginGmailUseCase: LoginGmailUseCaseProtocol = LoginGmailUseCase(),
+        monthlyBudgetUseCase: MonthlyBudgetUseCase = .shared,
+        firebaseRealtimeDBUseCase: FirebaseRealtimeDBUseCase = .shared
+    ) {
         self.user = user
         self.loginGmailUseCase = loginGmailUseCase
+        self.monthlyBudgetUseCase = monthlyBudgetUseCase
+        self.firebaseRealtimeDBUseCase = firebaseRealtimeDBUseCase
+        selectedCurrency = Constants.AppData.currencyList.first ?? "THB"
+        loadBudgetForSelectedMonth()
+    }
+
+    func onAppear() {
+        loadBudgetProgress()
     }
 
     func onTapSignOut() {
@@ -27,6 +74,237 @@ final class ProfileScreenViewModel: ObservableObject {
             authState = .signedOut
         } catch let error {
             authState = .error(message: error.localizedDescription)
+        }
+    }
+
+    func showBudgetSection() {
+        isUpdateBudgetVisible = true
+        selectedDate = .now
+        loadBudgetForSelectedMonth()
+    }
+
+    func onTapUpdateBudget() {
+        isUpdateBudgetVisible = true
+        selectedDate = .now
+        loadBudgetForSelectedMonth()
+    }
+
+    func onTapViewBudgetExpenses() {
+        isBudgetExpenseSheetPresented = true
+    }
+
+    func onDismissBudgetExpenseSheet() {
+        recalculateBudgetProgressFromSelectedItems()
+        isBudgetExpenseSheetPresented = false
+    }
+
+    func onToggleBudgetExpenseItem(id: String) {
+        guard let index = budgetExpenseItems.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        var updatedItems = budgetExpenseItems
+        updatedItems[index].isSelected.toggle()
+        budgetExpenseItems = updatedItems
+        recalculateBudgetProgressFromSelectedItems()
+    }
+
+    func onSelectedDateChanged() {
+        loadBudgetForSelectedMonth()
+    }
+
+    func onTapSaveBudget() {
+        guard let amount = Double(budgetAmount), amount > 0 else {
+            isSaveSuccess = false
+            isShowingAlert = true
+            return
+        }
+
+        do {
+            try monthlyBudgetUseCase.saveBudget(
+                amount: amount,
+                currency: selectedCurrency,
+                date: selectedDate
+            )
+            isSaveSuccess = true
+            isShowingAlert = true
+            isUpdateBudgetVisible = false
+            applySavedBudgetToProgress(amount: amount)
+        } catch {
+            isSaveSuccess = false
+            isShowingAlert = true
+        }
+    }
+
+    private var isSelectedDateCurrentMonth: Bool {
+        let calendar = Calendar.current
+        return calendar.isDate(selectedDate, equalTo: .now, toGranularity: .month)
+    }
+
+    private func applySavedBudgetToProgress(amount: Double) {
+        if isSelectedDateCurrentMonth {
+            let spentAmount = budgetProgressUIModel?.spentAmount ?? 0
+            budgetProgressUIModel = BudgetProgressUIModel(
+                remainingAmount: max(amount - spentAmount, 0),
+                spentAmount: spentAmount,
+                budgetAmount: amount,
+                currency: selectedCurrency
+            )
+            loadBudgetProgress()
+        } else {
+            refreshCurrentMonthBudgetProgress()
+        }
+    }
+
+    private func refreshCurrentMonthBudgetProgress() {
+        let components = Calendar.current.dateComponents(
+            [.month, .year],
+            from: .now
+        )
+        guard let month = components.month, let year = components.year else {
+            hasCurrentMonthBudget = false
+            budgetProgressUIModel = nil
+            return
+        }
+        updateBudgetProgress(month: month, year: year)
+    }
+
+    private func updateBudgetProgress(month: Int, year: Int) {
+        guard let budget = monthlyBudgetUseCase.fetchBudget(month: month, year: year) else {
+            hasCurrentMonthBudget = false
+            budgetProgressUIModel = nil
+            budgetExpenseItems = []
+            return
+        }
+
+        hasCurrentMonthBudget = true
+        currentMonthBudgetAmount = budget.amount
+        currentMonthBudgetCurrency = budget.currency
+        let requestId = UUID()
+        budgetProgressRequestId = requestId
+        let yearMonthKey = yearMonthKey(month: month, year: year)
+        let previousSpent = budgetProgressUIModel?.spentAmount ?? 0
+
+        budgetProgressUIModel = BudgetProgressUIModel(
+            remainingAmount: max(budget.amount - previousSpent, 0),
+            spentAmount: previousSpent,
+            budgetAmount: budget.amount,
+            currency: budget.currency
+        )
+
+        firebaseRealtimeDBUseCase.getRecentExpenseLists(
+            queryLimit: monthlyExpenseQueryLimit
+        ) { [weak self] dataList in
+            Task { @MainActor in
+                guard let self, self.budgetProgressRequestId == requestId else { return }
+                guard let currentBudget = self.monthlyBudgetUseCase.fetchBudget(
+                    month: month,
+                    year: year
+                ) else { return }
+
+                self.currentMonthBudgetAmount = currentBudget.amount
+                self.currentMonthBudgetCurrency = currentBudget.currency
+                let expenseItems = self.buildBudgetExpenseItems(
+                    from: dataList ?? [],
+                    yearMonthKey: yearMonthKey,
+                    budgetCurrency: currentBudget.currency
+                )
+                self.budgetExpenseItems = self.mergeExpenseItemSelections(
+                    newItems: expenseItems
+                )
+                self.recalculateBudgetProgressFromSelectedItems()
+            }
+        }
+    }
+
+    func loadBudgetProgress() {
+        let components = Calendar.current.dateComponents(
+            [.month, .year],
+            from: .now
+        )
+        guard let month = components.month, let year = components.year else {
+            hasCurrentMonthBudget = false
+            budgetProgressUIModel = nil
+            return
+        }
+
+        updateBudgetProgress(month: month, year: year)
+    }
+
+    private func yearMonthKey(month: Int, year: Int) -> String {
+        String(format: "%04d-%02d", year, month)
+    }
+
+    private func loadBudgetForSelectedMonth() {
+        let components = Calendar.current.dateComponents(
+            [.month, .year],
+            from: selectedDate
+        )
+        guard let month = components.month, let year = components.year else {
+            return
+        }
+
+        if let budget = monthlyBudgetUseCase.fetchBudget(month: month, year: year) {
+            budgetAmount = budget.amount.fractionTwoDigitString
+            selectedCurrency = budget.currency
+            selectedDate = budget.budgetDate
+        } else {
+            budgetAmount = ""
+            selectedCurrency = Constants.AppData.currencyList.first ?? "THB"
+        }
+    }
+
+    func recalculateBudgetProgressFromSelectedItems() {
+        guard hasCurrentMonthBudget else { return }
+
+        let spentAmount = budgetExpenseItems
+            .filter(\.isSelected)
+            .reduce(0.0) { $0 + $1.cost }
+
+        budgetProgressUIModel = BudgetProgressUIModel(
+            remainingAmount: max(currentMonthBudgetAmount - spentAmount, 0),
+            spentAmount: spentAmount,
+            budgetAmount: currentMonthBudgetAmount,
+            currency: currentMonthBudgetCurrency
+        )
+    }
+
+    private func buildBudgetExpenseItems(
+        from expenseLists: [ExpenseList],
+        yearMonthKey: String,
+        budgetCurrency: String
+    ) -> [BudgetExpenseItemUIModel] {
+        expenseLists
+            .filter { $0.dateTime.yearMonthKey == yearMonthKey }
+            .flatMap { expenseList in
+                let listId = expenseList.id ?? expenseList.dateTime
+                let expenseCurrency = expenseList.currency ?? "THB"
+                let conversionRate = Constants.AppData.currencyConversionRate(
+                    fromCurrency: expenseCurrency,
+                    toCurrency: budgetCurrency
+                )
+                return expenseList.expenses.enumerated().map { index, expense in
+                    BudgetExpenseItemUIModel(
+                        id: "\(listId)-\(index)-\(expense.name)-\(expense.price)",
+                        name: expense.name,
+                        cost: expense.price * conversionRate,
+                        isSelected: true
+                    )
+                }
+            }
+    }
+
+    private func mergeExpenseItemSelections(
+        newItems: [BudgetExpenseItemUIModel]
+    ) -> [BudgetExpenseItemUIModel] {
+        let selectionMap = Dictionary(
+            uniqueKeysWithValues: budgetExpenseItems.map { ($0.id, $0.isSelected) }
+        )
+        return newItems.map { item in
+            var updatedItem = item
+            if let isSelected = selectionMap[item.id] {
+                updatedItem.isSelected = isSelected
+            }
+            return updatedItem
         }
     }
 }

--- a/ExpenseTracker/ExpenseTracker/Presentation/Tabs/TabScreen.swift
+++ b/ExpenseTracker/ExpenseTracker/Presentation/Tabs/TabScreen.swift
@@ -9,28 +9,42 @@ import SwiftUI
 
 struct TabScreen: View {
 
+    private enum TabItem: Int {
+        case add = 0
+        case history = 1
+        case analysis = 2
+        case profile = 3
+    }
+
     @EnvironmentObject var navigator: AppCoordinatorViewModel
     @StateObject private var addExpenseViewModel: AddExpenseViewModel
     @StateObject private var expenseHistoryViewModel: ExpenseHistoryViewModel
     @StateObject private var expenseAnalysisViewModel: ExpenseAnalysisViewModel
     @StateObject private var profileScreenViewModel: ProfileScreenViewModel
-    
+
+    @State private var selectedTab = TabItem.add.rawValue
+    @State private var isShowingBudgetAlert = false
+
     private let user: User
+    private let monthlyBudgetUseCase: MonthlyBudgetUseCase
 
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             AddExpenseScreen(viewModel: addExpenseViewModel)
                 .tabItem {
                     Label(Constants.AppText.tabAdd, systemImage: "note.text.badge.plus")
                 }
+                .tag(TabItem.add.rawValue)
             ExpenseHistoryScreen(viewModel: expenseHistoryViewModel)
                 .tabItem {
                     Label(Constants.AppText.tabHistory, systemImage: "list.bullet.rectangle")
                 }
+                .tag(TabItem.history.rawValue)
             ExpenseAnalysisScreen(viewModel: expenseAnalysisViewModel)
                 .tabItem {
                     Label(Constants.AppText.tabAnalysis, systemImage: "chart.bar.xaxis")
                 }
+                .tag(TabItem.analysis.rawValue)
             ProfileScreen(
                 viewModel: profileScreenViewModel,
                 onSignOutSuccess: {
@@ -40,16 +54,42 @@ struct TabScreen: View {
             .tabItem {
                 Label(Constants.AppText.tabProfile, systemImage: "person.crop.circle.fill")
             }
+            .tag(TabItem.profile.rawValue)
         }
         .tint(Color(hexString: Constants.AppColors.tabSelectionColor))
         .environmentObject(navigator)
+        .onAppear {
+            checkMonthlyBudget()
+        }
+        .alert(
+            Constants.AppText.budgetAlertTitle,
+            isPresented: $isShowingBudgetAlert
+        ) {
+            Button(Constants.AppText.cancel, role: .cancel) { }
+            Button(Constants.AppText.setBudget) {
+                selectedTab = TabItem.profile.rawValue
+                profileScreenViewModel.showBudgetSection()
+            }
+        } message: {
+            Text(Constants.AppText.budgetAlertMessage)
+        }
     }
 
-    init(user: User) {
+    init(
+        user: User,
+        monthlyBudgetUseCase: MonthlyBudgetUseCase = .shared
+    ) {
         self.user = user
+        self.monthlyBudgetUseCase = monthlyBudgetUseCase
         _addExpenseViewModel = StateObject(wrappedValue: AddExpenseViewModel())
         _expenseHistoryViewModel = StateObject(wrappedValue: ExpenseHistoryViewModel())
         _expenseAnalysisViewModel = StateObject(wrappedValue: ExpenseAnalysisViewModel())
         _profileScreenViewModel = StateObject(wrappedValue: ProfileScreenViewModel(user: user))
+    }
+
+    private func checkMonthlyBudget() {
+        if !monthlyBudgetUseCase.hasBudgetForCurrentMonth() {
+            isShowingBudgetAlert = true
+        }
     }
 }

--- a/ExpenseTracker/ExpenseTracker/Presentation/UIModel/BudgetExpenseItemUIModel.swift
+++ b/ExpenseTracker/ExpenseTracker/Presentation/UIModel/BudgetExpenseItemUIModel.swift
@@ -1,0 +1,16 @@
+//
+//  BudgetExpenseItemUIModel.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 8/7/26.
+//
+
+import Foundation
+
+struct BudgetExpenseItemUIModel: Identifiable, Equatable {
+
+    let id: String
+    let name: String
+    let cost: Double
+    var isSelected: Bool
+}

--- a/ExpenseTracker/ExpenseTracker/Presentation/UIModel/BudgetProgressUIModel.swift
+++ b/ExpenseTracker/ExpenseTracker/Presentation/UIModel/BudgetProgressUIModel.swift
@@ -1,0 +1,21 @@
+//
+//  BudgetProgressUIModel.swift
+//  ExpenseTracker
+//
+//  Created by Taher on 7/7/26.
+//
+
+import Foundation
+
+struct BudgetProgressUIModel: Equatable {
+
+    let remainingAmount: Double
+    let spentAmount: Double
+    let budgetAmount: Double
+    let currency: String
+
+    var spentFraction: Double {
+        guard budgetAmount > 0 else { return 0 }
+        return min(spentAmount / budgetAmount, 1.0)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds monthly budget setup on Profile with SwiftData persistence (amount, currency, and month).
- Shows a budget progress bar for the current month (spent vs remaining) using Firebase expense data.
- Prompts users on app open when no current-month budget is set, with navigation to Profile to configure it.
- Adds a bottom sheet to filter monthly expenses via checkboxes; excluded items update spent/remaining in real time.
- Includes supporting UI models, use cases, and Cursor project rules for Swift conventions.

## Test plan
- [ ] Sign in and open the app without a current-month budget; verify alert appears with Cancel and Set budget actions.
- [ ] Set a monthly budget on Profile (amount, currency, date) and confirm it saves successfully.
- [ ] Verify progress bar shows correct spent, remaining, and usage text for the current month.
- [ ] Tap **Filter expenses**, unselect one or more items, tap Done, and confirm progress values update.
- [ ] Tap **Update budget**, change amount/currency, save, and confirm progress bar refreshes.
- [ ] Relaunch app and confirm budget persists and alert no longer appears for the current month.
- [ ] Run `xcodebuild` build for ExpenseTracker scheme on iOS Simulator.


Made with [Cursor](https://cursor.com)